### PR TITLE
Fix makefiles for various configurations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ $(PACKAGE): all
 	cp -r settings/CylinderSettings.bundle .tmp/Library/PreferenceBundles
 	cp settings/CylinderSettingsLoader.plist .tmp/Library/PreferenceLoader/Preferences/
 	cp -r DEBIAN .tmp/
-	dpkg-deb -b .tmp
+	dpkg-deb -Zgzip -b .tmp
 	mv .tmp.deb $(PACKAGE)
 	rm -rf .tmp
 

--- a/settings/Makefile
+++ b/settings/Makefile
@@ -19,7 +19,8 @@ NAME=Cylinder
 
 CC=xcrun -sdk iphoneos clang
 ARCH=-arch armv7 -arch arm64
-SDKS=-mios-version-min=3.0 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.0.sdk
+DEVELOPER_DIR=`xcode-select --print-path`
+SDKS=-mios-version-min=3.0 -isysroot $(DEVELOPER_DIR)/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7*.sdk
 #ARC=-fobjc-arc
 FRAMEWORKS=-framework Foundation -framework UIKit -framework QuartzCore -framework AVFoundation
 FLAGS= -dynamiclib -undefined suppress -flat_namespace -I../include -I../include/iphoneheaders -I../include/iphoneheaders/_fallback

--- a/tweak/Makefile
+++ b/tweak/Makefile
@@ -21,7 +21,8 @@ SCP=scp #-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
 
 CC=xcrun -sdk iphoneos clang
 ARCH=-arch armv7 -arch arm64
-SDKS=-mios-version-min=3.0 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.0.sdk
+DEVELOPER_DIR=`xcode-select --print-path`
+SDKS=-mios-version-min=3.0 -isysroot $(DEVELOPER_DIR)/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7*.sdk
 #ARC=-fobjc-arc
 INCLUDES= -I../include -I../include/iphoneheaders -I../include/iphoneheaders/_fallback
 FRAMEWORKS=-framework Foundation -framework UIKit -framework QuartzCore -framework CoreGraphics


### PR DESCRIPTION
Just some small fixes to the makefiles, for compatibility with:
- the iOS 7.1 SDK
- Xcodes that aren't installed in `/Applications/Xcode.app` (e.g. beta copies)
- versions of `dpkg-deb` that don't compress with gzip by default and confuse the device, like the one installed from Homebrew.

Should be pretty self-explanatory. (Also, ignore the first two commits; they cancel each other out since the showAllIcons hook was added back in in 5fcf223…)

BTW: I'm also working on dynamically creating & destroying transform layers to hopefully fix #17 once and for all without all the glitchiness. It's on a feature branch, but at the moment it's a little too buggy and hacky for a merge.
