### PR TITLE
Remove silly 'hi'

### DIFF
--- a/settings/Resources/CylinderSettings.plist
+++ b/settings/Resources/CylinderSettings.plist
@@ -78,14 +78,6 @@
 		</dict>
 		<dict>
 			<key>cell</key>
-			<string>PSGroupCell</string>
-			<key>footerText</key>
-            <string>hi</string>
-			<key>isStaticText</key>
-			<true/>
-		</dict>
-		<dict>
-			<key>cell</key>
 			<string>PSLinkListCell</string>
 			<key>default</key>
 			<string></string>


### PR DESCRIPTION
I just don't see the need for it.
