### PR TITLE
Remove deprecations to build with new SDKs

### DIFF
--- a/deps/src/lua/loslib.c
+++ b/deps/src/lua/loslib.c
@@ -79,7 +79,7 @@
 
 static int os_execute (lua_State *L) {
   const char *cmd = luaL_optstring(L, 1, NULL);
-  int stat = system(cmd);
+  int stat = 0;
   if (cmd != NULL)
     return luaL_execresult(L, stat);
   else {
@@ -104,8 +104,7 @@ static int os_rename (lua_State *L) {
 
 static int os_tmpname (lua_State *L) {
   char buff[LUA_TMPNAMBUFSIZE];
-  int err;
-  lua_tmpnam(buff, err);
+  int err = 1;
   if (err)
     return luaL_error(L, "unable to generate a unique filename");
   lua_pushstring(L, buff);


### PR DESCRIPTION
Fixes #77 

os_execute and os_tmpname aren't used by Cylinder anyways.